### PR TITLE
include a minimum rust version policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ changelog and release notes. Once we have found an API that is sane and stable,
 we will release a 1.0, after which point, all versions of the 1.X line will be
 backwards compatible per [semver](https://semver.org).
 
+## Minimum Supported Rust Version
+
+This crate supports Rust Language 2018 Edition and currently commits to working
+with stable Rust version 1.47 and later. It requires `std`.
+
+Going forward, it should support every stable version of Rust, and at any given
+time maintain compatibility with stable versions of Rust released in the past 6
+months or so.  In other words, it will not depend on language features or
+syntax just released as stable in the past 6 months.
+
 ## Contributing
 
 We :heart: any contributions. Any fixes to make things simpler or more idiomatic


### PR DESCRIPTION
This should close #41 .

I guess we could not mention a specific rust version in the README itself, so that we wouldn't need to update/maintain it over time, but it is also clearer to give a specific version. I could go either way.