### PR TITLE
Update MSRV to 1.56, and edition to 2021. Also, actually set edition in Cargo.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install 1.47 toolchain
+      - name: Install 1.56 toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: '1.47'
+          toolchain: '1.56'
           override: true
       - name: Build
         run: cargo build
@@ -40,10 +40,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install 1.47 toolchain
+      - name: Install 1.56 toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: '1.47'
+          toolchain: '1.56'
           override: true
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "macaroon"
 version = "0.2.0"
 edition = "2018"
-rust-version = "1.47"
+rust-version = "1.56"
 authors = ["Jack Lund <jackl@geekheads.net>", "macaroon-rs Contributors"]
 description = "Fully functional implementation of macaroons in Rust"
 documentation = "https://docs.rs/macaroon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "macaroon"
 version = "0.2.0"
+edition = "2018"
+rust-version = "1.47"
 authors = ["Jack Lund <jackl@geekheads.net>", "macaroon-rs Contributors"]
 description = "Fully functional implementation of macaroons in Rust"
 documentation = "https://docs.rs/macaroon"

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ backwards compatible per [semver](https://semver.org).
 
 ## Minimum Supported Rust Version
 
-This crate supports Rust Language 2018 Edition and currently commits to working
-with stable Rust version 1.47 and later. It requires `std`.
+This crate supports Rust Language 2021 Edition and currently commits to working
+with stable Rust version 1.56 and later. It requires `std`.
 
 Going forward, it should support every stable version of Rust, and at any given
 time maintain compatibility with stable versions of Rust released in the past 6

--- a/src/caveat.rs
+++ b/src/caveat.rs
@@ -1,9 +1,9 @@
-use crypto;
+use crate::crypto;
+use crate::error::MacaroonError;
+use crate::ByteString;
+use crate::Result;
 use crypto::MacaroonKey;
-use error::MacaroonError;
 use std::fmt::Debug;
-use ByteString;
-use Result;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Caveat {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,9 +1,9 @@
-use error::MacaroonError;
+use crate::error::MacaroonError;
+use crate::Result;
 use sodiumoxide::crypto::auth::hmacsha512256::{authenticate, gen_key, Key, Tag};
 use sodiumoxide::crypto::secretbox;
 use std::borrow::Borrow;
 use std::ops::{Deref, DerefMut};
-use Result;
 
 const KEY_GENERATOR: MacaroonKey = MacaroonKey(*b"macaroons-key-generator\0\0\0\0\0\0\0\0\0");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,11 +363,7 @@ impl Macaroon {
 
 #[cfg(test)]
 mod tests {
-    use super::ByteString;
-    use super::Caveat;
-    use super::Macaroon;
-    use super::MacaroonKey;
-    use Result;
+    use crate::{ByteString, Caveat, Macaroon, MacaroonKey, Result};
 
     #[test]
     fn create_macaroon() {

--- a/src/serialization/macaroon_builder.rs
+++ b/src/serialization/macaroon_builder.rs
@@ -1,9 +1,6 @@
-use caveat::Caveat;
-use error::MacaroonError;
-use ByteString;
-use Macaroon;
-use MacaroonKey;
-use Result;
+use crate::caveat::Caveat;
+use crate::error::MacaroonError;
+use crate::{ByteString, Macaroon, MacaroonKey, Result};
 
 #[derive(Default)]
 pub struct MacaroonBuilder {

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -1,10 +1,8 @@
-use caveat::{Caveat, CaveatBuilder};
-use error::MacaroonError;
-use serialization::macaroon_builder::MacaroonBuilder;
+use crate::caveat::{Caveat, CaveatBuilder};
+use crate::error::MacaroonError;
+use crate::serialization::macaroon_builder::MacaroonBuilder;
+use crate::{ByteString, Macaroon, Result};
 use std::str;
-use ByteString;
-use Macaroon;
-use Result;
 
 // Version 1 fields
 const LOCATION: &str = "location";
@@ -156,10 +154,7 @@ pub fn deserialize(base64: &[u8]) -> Result<Macaroon> {
 
 #[cfg(test)]
 mod tests {
-    use ByteString;
-    use Caveat;
-    use Macaroon;
-    use MacaroonKey;
+    use crate::{ByteString, Caveat, Macaroon, MacaroonKey};
 
     #[test]
     fn test_deserialize() {

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -1,9 +1,7 @@
-use caveat::{Caveat, CaveatBuilder};
-use error::MacaroonError;
-use serialization::macaroon_builder::MacaroonBuilder;
-use ByteString;
-use Macaroon;
-use Result;
+use crate::caveat::{Caveat, CaveatBuilder};
+use crate::error::MacaroonError;
+use crate::serialization::macaroon_builder::MacaroonBuilder;
+use crate::{ByteString, Macaroon, Result};
 
 // Version 2 fields
 const EOS: u8 = 0;
@@ -230,12 +228,10 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon> {
 
 #[cfg(test)]
 mod tests {
-    use caveat;
-    use caveat::Caveat;
-    use serialization::macaroon_builder::MacaroonBuilder;
-    use ByteString;
-    use Macaroon;
-    use MacaroonKey;
+    use crate::caveat;
+    use crate::caveat::Caveat;
+    use crate::serialization::macaroon_builder::MacaroonBuilder;
+    use crate::{ByteString, Macaroon, MacaroonKey};
 
     #[test]
     fn test_deserialize() {

--- a/src/serialization/v2json.rs
+++ b/src/serialization/v2json.rs
@@ -1,13 +1,11 @@
-use caveat;
-use caveat::CaveatBuilder;
-use error::MacaroonError;
+use crate::caveat;
+use crate::caveat::CaveatBuilder;
+use crate::error::MacaroonError;
+use crate::serialization::macaroon_builder::MacaroonBuilder;
+use crate::{ByteString, Macaroon, Result};
 use serde::{Deserialize, Serialize};
 use serde_json;
-use serialization::macaroon_builder::MacaroonBuilder;
 use std::str;
-use ByteString;
-use Macaroon;
-use Result;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct Caveat {
@@ -195,10 +193,7 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon> {
 #[cfg(test)]
 mod tests {
     use super::super::Format;
-    use ByteString;
-    use Caveat;
-    use Macaroon;
-    use MacaroonKey;
+    use crate::{ByteString, Caveat, Macaroon, MacaroonKey};
 
     const SERIALIZED_JSON: &str = "{\"v\":2,\"l\":\"http://example.org/\",\"i\":\"keyid\",\
                                    \"c\":[{\"i\":\"account = 3735928559\"},{\"i\":\"user = \

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,12 +1,7 @@
-use crypto;
+use crate::crypto;
+use crate::{ByteString, Caveat, Macaroon, MacaroonError, MacaroonKey, Result};
 use std::collections::BTreeSet;
 use std::collections::HashMap;
-use ByteString;
-use Caveat;
-use Macaroon;
-use MacaroonError;
-use MacaroonKey;
-use Result;
 
 pub type VerifyFunc = fn(&ByteString) -> bool;
 
@@ -99,9 +94,7 @@ mod tests {
     extern crate time;
 
     use super::Verifier;
-    use ByteString;
-    use Macaroon;
-    use MacaroonKey;
+    use crate::{ByteString, Macaroon, MacaroonKey};
 
     #[test]
     fn test_simple_macaroon() {


### PR DESCRIPTION
Our README previously said that we support the 2018 edition of Rust, but this wasn't actually set in the Cargo.toml.

Recent CI runs have been failing for all branches, because some (recursive) dependencies are now up to 2021. I would have sort of hoped that setting edition=2018, and not having a Cargo.lock, would have resulted in `cargo` choosing a compatible set of libraries (aka, not using edition=2021), but this doesn't seem to be the case. CI was broken, and adding this crate to a project today using rust 1.47 would not have worked in real life, I think.

This PR sets the edition to 2021, and bumps the MSRV to 1.56, which was released in October 2021. 1.56 was the first version of Rust that supported the 2021 edition. Also updated CI and the README.

This PR also fixes a bunch of imports which were broken with the newer rust edition (aka, by adding a `crate::` prefix to `use` statements).

I first tried to just add edition=2018, but that didn't work.