### PR TITLE
Update `time` dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ license = "MIT"
 
 [dependencies]
 log = "0.4"
-serde = { version= "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sodiumoxide = "0.2"
 base64 = "0.13"
 
 [dev-dependencies]
 env_logger = "0.9"
-time = "0.2.16"
+time = { version = "0.3", features = ["parsing"] }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -192,8 +192,12 @@ mod tests {
             Err(_) => return false,
         };
 
-        match time::OffsetDateTime::parse(&strcaveat[7..], "%Y-%m-%dT%H:%M%z") {
-            Ok(compare) => time::OffsetDateTime::now_local() > compare,
+        let format = time::format_description::parse(
+            "[year]-[month]-[day]T[hour]:[minute][offset_hour sign:mandatory][offset_minute]",
+        )
+        .unwrap();
+        match time::OffsetDateTime::parse(&strcaveat[7..], &format) {
+            Ok(compare) => time::OffsetDateTime::now_utc() > compare,
             Err(_) => false,
         }
     }


### PR DESCRIPTION
There were some upstream API changes (in `time`), resulting in deprecation notices on the 0.2.x version of this library.