### PR TITLE
clippy lints

### DIFF
--- a/src/caveat.rs
+++ b/src/caveat.rs
@@ -5,13 +5,13 @@ use crate::Result;
 use crypto::MacaroonKey;
 use std::fmt::Debug;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Caveat {
     FirstParty(FirstParty),
     ThirdParty(ThirdParty),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FirstParty {
     predicate: ByteString,
 }
@@ -22,7 +22,7 @@ impl FirstParty {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ThirdParty {
     id: ByteString,
     verifier_id: ByteString,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -9,7 +9,7 @@ const KEY_GENERATOR: MacaroonKey = MacaroonKey(*b"macaroons-key-generator\0\0\0\
 
 // A convenience type for a MacaroonKey with helpful methods attached for
 // conversion. Using the default trait will return a randomly generated key
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MacaroonKey([u8; sodiumoxide::crypto::auth::KEYBYTES]);
 
 impl Default for MacaroonKey {
@@ -101,7 +101,7 @@ where
     let MacaroonKey(tmp1) = hmac(key, text1);
     let MacaroonKey(tmp2) = hmac(key, text2);
     let tmp = [tmp1, tmp2].concat();
-    hmac(key, &tmp.to_vec())
+    hmac(key, &tmp)
 }
 
 pub fn encrypt_key<T>(key: &T, plaintext: &T) -> Vec<u8>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub fn initialize() -> Result<()> {
 // An implementation that represents any binary data. By spec, most fields in a
 // macaroon support binary encoded as base64, so ByteString has methods to
 // convert to and from base64 strings
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ByteString(pub Vec<u8>);
 
 impl AsRef<[u8]> for ByteString {
@@ -164,12 +164,6 @@ impl From<[u8; 32]> for ByteString {
 impl From<MacaroonKey> for ByteString {
     fn from(k: MacaroonKey) -> ByteString {
         ByteString(k.to_vec())
-    }
-}
-
-impl Default for ByteString {
-    fn default() -> ByteString {
-        ByteString(Default::default())
     }
 }
 
@@ -218,7 +212,7 @@ impl<'de> Deserialize<'de> for ByteString {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Macaroon {
     identifier: ByteString,
     location: Option<String>,

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -33,7 +33,7 @@ fn serialize_field(tag: u8, value: &[u8], buffer: &mut Vec<u8>) {
 pub fn serialize(macaroon: &Macaroon) -> Result<Vec<u8>> {
     let mut buffer: Vec<u8> = vec![2 /* version */];
     if let Some(ref location) = macaroon.location() {
-        serialize_field(LOCATION, &location.as_bytes().to_vec(), &mut buffer);
+        serialize_field(LOCATION, location.as_bytes(), &mut buffer);
     };
     serialize_field(IDENTIFIER, &macaroon.identifier().0, &mut buffer);
     buffer.push(EOS);


### PR DESCRIPTION
Small changes to make clippy happy: might as well derive `Eq` for some types, and `to_vec()` not needed.