### PR TITLE
actually use 2021 edition, and note MSRV+edition in changelog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "macaroon"
 version = "0.3.0-dev.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 authors = ["Jack Lund <jackl@geekheads.net>", "macaroon-rs Contributors"]
 description = "Fully functional implementation of macaroons in Rust"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ This is a backwards-incompatible release with respect to serialized macaroon sig
 
 - Revert HMAC back to SHA-256 (breaks signatures)
 - Dependency updates
+- Update Rust edition to 2021, and minimum required Rust version to v1.56
 
 ## Version 0.2.0 - Sep 24, 2021 (macaroon)
 


### PR DESCRIPTION
A previous commit updated the README to mention 2021 edition, but accidentally only actually set the edition to 2021.

This PR actually sets the edition to 2021 in the Cargo metadata, and updates the changelog.

Thanks to @dunxen for noticing the issue in the review of another PR.