### PR TITLE
iterate on MacaroonKey API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use macaroon::{Macaroon, Verifier, MacaroonKey};
 macaroon::initialize().unwrap(); // Force panic if initialization fails
 
 // Create our key
-let key = "key".into();
+let key = MacaroonKey::generate(b"key");
 
 // Create our macaroon. A location is optional.
 let mut macaroon = match Macaroon::create(Some("location".into()), &key, "id".into()) {
@@ -88,7 +88,7 @@ match verifier.verify(&macaroon, &key, Default::default()) {
 // to authorize this for us as well.
 
 // Create a key for the third party caveat
-let other_key = "different key".into();
+let other_key = MacaroonKey::generate(b"different key");
 
 macaroon.add_third_party_caveat("https://auth.mybank", &other_key, "caveat id".into());
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -12,18 +12,6 @@ const KEY_GENERATOR: MacaroonKey = MacaroonKey(*b"macaroons-key-generator\0\0\0\
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MacaroonKey([u8; sodiumoxide::crypto::auth::KEYBYTES]);
 
-impl Default for MacaroonKey {
-    /// Generate a new random key.
-    ///
-    /// ```rust
-    /// # use macaroon::MacaroonKey;
-    /// let key = MacaroonKey::default();
-    /// ```
-    fn default() -> Self {
-        MacaroonKey(gen_key().0)
-    }
-}
-
 impl AsRef<[u8; sodiumoxide::crypto::auth::KEYBYTES]> for MacaroonKey {
     fn as_ref(&self) -> &[u8; sodiumoxide::crypto::auth::KEYBYTES] {
         &self.0
@@ -77,6 +65,16 @@ impl From<&[u8; sodiumoxide::crypto::auth::KEYBYTES]> for MacaroonKey {
 }
 
 impl MacaroonKey {
+    /// Generate a new random key, using a secure random number generator.
+    ///
+    /// ```rust
+    /// # use macaroon::MacaroonKey;
+    /// let key = MacaroonKey::generate_random();
+    /// ```
+    pub fn generate_random() -> Self {
+        MacaroonKey(gen_key().0)
+    }
+
     /// Use some seed data to reproducibly generate a MacaroonKey via HMAC.
     ///
     /// ```rust

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -7,8 +7,38 @@ use std::ops::{Deref, DerefMut};
 
 const KEY_GENERATOR: MacaroonKey = MacaroonKey(*b"macaroons-key-generator\0\0\0\0\0\0\0\0\0");
 
-/// A convenience type for a secret MacaroonKey with helpful methods attached for conversion. Using
-/// the default trait will return a randomly generated key.
+/// Secret cryptographic key used to sign and verify Macaroons.
+///
+/// This is a wrapper type around an array of bytes of the correct size for the underlying
+/// cryptographic primatives (currently 32 bytes). Keys can be either provided verbatim as raw
+/// bytes; generated randomly; or generated via an HMAC from a byte string of any length. For
+/// security, keys should be generated using at least 32 bytes of entropy, and stored securely.
+///
+/// No special techniques are used by this crate to keep key material safe in memory. The `Debug`
+/// trait will output the secret key material, which could end up leaked in logs.
+///
+/// ## Creation
+///
+/// ```rust
+/// # use std::error::Error;
+/// #
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// use macaroon::MacaroonKey;
+/// extern crate base64;
+///
+/// // generate a new random key from scratch
+/// let fresh_key = MacaroonKey::generate_random();
+///
+/// // generate from a byte string
+/// let weak_example_key = MacaroonKey::generate(b"some-secret-here");
+///
+/// // import a base64-encoded key (eg, from a secrets vault)
+/// let mut key_bytes: [u8; 32] = [0; 32];
+/// key_bytes.copy_from_slice(&base64::decode("zV/IaqNgsWe2c22J5ilLY/d9DbxEir2z1bYBrzBemsM=")?);
+/// let secret_key: MacaroonKey = key_bytes.into();
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MacaroonKey([u8; sodiumoxide::crypto::auth::KEYBYTES]);
 

--- a/src/serialization/macaroon_builder.rs
+++ b/src/serialization/macaroon_builder.rs
@@ -2,7 +2,6 @@ use crate::caveat::Caveat;
 use crate::error::MacaroonError;
 use crate::{ByteString, Macaroon, MacaroonKey, Result};
 
-#[derive(Default)]
 pub struct MacaroonBuilder {
     identifier: ByteString,
     location: Option<String>,
@@ -12,7 +11,12 @@ pub struct MacaroonBuilder {
 
 impl MacaroonBuilder {
     pub fn new() -> MacaroonBuilder {
-        Default::default()
+        MacaroonBuilder {
+            identifier: Default::default(),
+            location: None,
+            signature: MacaroonKey::generate_random(),
+            caveats: Default::default(),
+        }
     }
 
     pub fn set_identifier(&mut self, identifier: ByteString) {

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -238,7 +238,7 @@ mod tests {
     fn test_serialize_deserialize() {
         let mut macaroon: Macaroon = Macaroon::create(
             Some("http://example.org/".into()),
-            &"my key".into(),
+            &MacaroonKey::generate(b"my key"),
             "keyid".into(),
         )
         .unwrap();
@@ -246,7 +246,7 @@ mod tests {
         macaroon.add_first_party_caveat("user = alice".into());
         macaroon.add_third_party_caveat(
             "https://auth.mybank.com",
-            &"caveat key".into(),
+            &MacaroonKey::generate(b"caveat key"),
             "caveat".into(),
         );
         let serialized = macaroon.serialize(super::super::Format::V1).unwrap();

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -289,7 +289,7 @@ mod tests {
     fn test_serialize_deserialize() {
         let mut macaroon = Macaroon::create(
             Some("http://example.org/".into()),
-            &"key".into(),
+            &MacaroonKey::generate(b"key"),
             "keyid".into(),
         )
         .unwrap();
@@ -297,7 +297,7 @@ mod tests {
         macaroon.add_first_party_caveat("user = alice".into());
         macaroon.add_third_party_caveat(
             "https://auth.mybank.com",
-            &"caveat key".into(),
+            &MacaroonKey::generate(b"caveat key"),
             "caveat".into(),
         );
         let serialized = super::serialize(&macaroon).unwrap();

--- a/src/serialization/v2json.rs
+++ b/src/serialization/v2json.rs
@@ -235,7 +235,7 @@ mod tests {
         macaroon.add_first_party_caveat("user = alice".into());
         macaroon.add_third_party_caveat(
             "https://auth.mybank.com/",
-            &"my key".into(),
+            &MacaroonKey::generate(b"my key"),
             "keyid".into(),
         );
         let serialized = macaroon.serialize(Format::V2JSON).unwrap();

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_simple_macaroon() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let macaroon = Macaroon::create(None, &key, "testing".into()).unwrap();
         let verifier = Verifier::default();
         verifier
@@ -109,8 +109,9 @@ mod tests {
 
     #[test]
     fn test_simple_macaroon_bad_verifier_key() {
-        let macaroon = Macaroon::create(None, &"key".into(), "testing".into()).unwrap();
-        let key: MacaroonKey = "this is not the key".into();
+        let macaroon =
+            Macaroon::create(None, &MacaroonKey::generate(b"key"), "testing".into()).unwrap();
+        let key = MacaroonKey::generate(b"this is not the key");
         let verifier = Verifier::default();
         verifier
             .verify(&macaroon, &key, Default::default())
@@ -119,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_exact_caveat() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon = Macaroon::create(None, &key, "testing".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
         let mut verifier = Verifier::default();
@@ -131,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_exact_caveat_wrong_verifier() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon = Macaroon::create(None, &key, "testing".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
         let mut verifier = Verifier::default();
@@ -143,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_exact_caveat_wrong_context() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon = Macaroon::create(None, &key, "testing".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
         let verifier = Verifier::default();
@@ -154,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_two_exact_caveats() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon = Macaroon::create(None, &key, "testing".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
         macaroon.add_first_party_caveat("user = alice".into());
@@ -168,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_two_exact_caveats_incomplete_verifier() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon = Macaroon::create(None, &key, "testing".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
         macaroon.add_first_party_caveat("user = alice".into());
@@ -205,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_two_exact_and_one_general_caveat() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon =
             Macaroon::create(Some("http://example.org/".into()), &key, "keyid".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
@@ -222,7 +223,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_two_exact_and_one_general_fails_general() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon =
             Macaroon::create(Some("http://example.org/".into()), &key, "keyid".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
@@ -239,7 +240,7 @@ mod tests {
 
     #[test]
     fn test_macaroon_two_exact_and_one_general_incomplete_verifier() {
-        let key: MacaroonKey = "this is the key".into();
+        let key = MacaroonKey::generate(b"this is the key");
         let mut macaroon =
             Macaroon::create(Some("http://example.org/".into()), &key, "keyid".into()).unwrap();
         macaroon.add_first_party_caveat("account = 3735928559".into());
@@ -255,8 +256,8 @@ mod tests {
 
     #[test]
     fn test_macaroon_third_party_caveat() {
-        let root_key: MacaroonKey = "this is the key".into();
-        let another_key: MacaroonKey = "this is another key".into();
+        let root_key = MacaroonKey::generate(b"this is the key");
+        let another_key = MacaroonKey::generate(b"this is another key");
         let mut macaroon = Macaroon::create(
             Some("http://example.org/".into()),
             &root_key,
@@ -281,8 +282,8 @@ mod tests {
 
     #[test]
     fn test_macaroon_third_party_caveat_with_cycle() {
-        let root_key: MacaroonKey = "this is the key".into();
-        let another_key: MacaroonKey = "this is another key".into();
+        let root_key = MacaroonKey::generate(b"this is the key");
+        let another_key = MacaroonKey::generate(b"this is another key");
         let mut macaroon = Macaroon::create(
             Some("http://example.org/".into()),
             &root_key,


### PR DESCRIPTION
Makes two changes to trait implementations on `MacaroonKey` to have un-surprising behavior.

The first is to only implement `From` for the types that can be directly and unambiguously wrapped by `MacaroonKey`: `[u8; 32]` and `&[u8;32]`. For the other types (previously `&str` and arbitrary-length byte slices), we need to run an HMAC to get to a 32 byte key. I think it is better to make the HMAC generate path explicit, via a `generate()` function.

I thought about trying to use fancy trait bounds to make it easy to pass a `&str` as well as `&[u8]` to the `generate()` function, but ended up just keeping it simple. Open to figuring it out if the ergonomics are worth the complexity.

The second change was to make random generation of keys (using libsodium random byte generator) explicit as well, instead of using the `Default` trait. I think `Default` doesn't really make sense for generating a random value. This change required dropping `Default` on the `MacaroonBuilder` struct as well. That struct should maybe also be refactored? But I think is currently part of the public API so not as much of a priority.

Closes: https://github.com/macaroon-rs/macaroon/issues/66