### PR TITLE
Fix several `panic` errors found while fuzz testing

### DIFF
--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -77,6 +77,11 @@ fn deserialize_as_packets(data: &[u8], mut packets: Vec<Packet>) -> Result<Vec<P
     if data.is_empty() {
         return Ok(packets);
     }
+    if data.len() < 4 {
+        return Err(MacaroonError::DeserializationError(
+            "packet chunk too small to decode".to_string(),
+        ));
+    }
     let hex: &str = str::from_utf8(&data[..4])?;
     let size: usize = usize::from_str_radix(hex, 16)?;
     let packet_data = &data[4..size];
@@ -243,5 +248,6 @@ mod tests {
         assert!(super::deserialize(b"NDhJe_A==").is_err());
 
         // these failed fuzz testing for this deserializer (V1)
+        assert!(Macaroon::deserialize(&vec![70, 70, 102, 70]).is_err());
     }
 }

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -233,4 +233,15 @@ mod tests {
         let deserialized = Macaroon::deserialize(&serialized).unwrap();
         assert_eq!(macaroon, deserialized);
     }
+
+    #[test]
+    fn test_deserialize_bad_data() {
+        // these are all expected to fail... but not panic!
+        assert!(super::deserialize(b"").is_err());
+        assert!(super::deserialize(b"12345").is_err());
+        assert!(super::deserialize(b"\0").is_err());
+        assert!(super::deserialize(b"NDhJe_A==").is_err());
+
+        // these failed fuzz testing for this deserializer (V1)
+    }
 }

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -97,6 +97,11 @@ fn deserialize_as_packets(data: &[u8], mut packets: Vec<Packet>) -> Result<Vec<P
     let packet_data = &data[4..size];
     let index = split_index(packet_data)?;
     let (key_slice, value_slice) = packet_data.split_at(index);
+    if value_slice.len() < 2 {
+        return Err(MacaroonError::DeserializationError(
+            "packet value size too small".to_string(),
+        ));
+    }
     packets.push(Packet {
         key: String::from_utf8(key_slice.to_vec())?,
         // skip beginning space and terminating \n
@@ -270,6 +275,13 @@ mod tests {
                 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
                 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
                 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 44, 125, 59, 64,
+            ],
+            base64::URL_SAFE,
+        );
+        assert!(Macaroon::deserialize(&tok.as_bytes()).is_err());
+        let tok = base64::encode_config(
+            &[
+                48, 48, 49, 48, 49, 48, 52, 48, 48, 48, 48, 48, 48, 48, 48, 32, 126, 10,
             ],
             base64::URL_SAFE,
         );

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -89,6 +89,11 @@ fn deserialize_as_packets(data: &[u8], mut packets: Vec<Packet>) -> Result<Vec<P
             "packet chunk size larger than token".to_string(),
         ));
     }
+    if size <= 4 {
+        return Err(MacaroonError::DeserializationError(
+            "packet chunk size too small".to_string(),
+        ));
+    }
     let packet_data = &data[4..size];
     let index = split_index(packet_data)?;
     let (key_slice, value_slice) = packet_data.split_at(index);
@@ -256,6 +261,16 @@ mod tests {
         assert!(Macaroon::deserialize(&vec![70, 70, 102, 70]).is_err());
         let tok = base64::encode_config(
             &[97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 10],
+            base64::URL_SAFE,
+        );
+        assert!(Macaroon::deserialize(&tok.as_bytes()).is_err());
+        let tok = base64::encode_config(
+            &[
+                48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+                48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+                48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+                48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 44, 125, 59, 64,
+            ],
             base64::URL_SAFE,
         );
         assert!(Macaroon::deserialize(&tok.as_bytes()).is_err());

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -11,6 +11,7 @@ const VID: u8 = 4;
 const SIGNATURE: u8 = 6;
 
 const VARINT_PACK_SIZE: usize = 128;
+const MAX_FIELD_SIZE_BYTES: usize = 65535;
 
 fn varint_size(size: usize) -> Vec<u8> {
     let mut buffer: Vec<u8> = Vec::new();
@@ -115,6 +116,12 @@ impl<'r> Deserializer<'r> {
                 size |= ((byte & 127) as usize) << shift;
             } else {
                 size |= (byte as usize) << shift;
+                if size > MAX_FIELD_SIZE_BYTES {
+                    return Err(MacaroonError::DeserializationError(format!(
+                        "field size too large ({} > {})",
+                        size, MAX_FIELD_SIZE_BYTES
+                    )));
+                }
                 return Ok(size);
             }
             shift += 7;

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -109,12 +109,12 @@ impl<'r> Deserializer<'r> {
         let mut size: usize = 0;
         let mut shift: usize = 0;
         let mut byte: u8;
-        while shift <= 63 {
+        while shift <= (usize::BITS - 8) as usize {
             byte = self.get_byte()?;
             if byte & 128 != 0 {
-                size |= ((byte & 127) << shift) as usize;
+                size |= ((byte & 127) as usize) << shift;
             } else {
-                size |= (byte << shift) as usize;
+                size |= (byte as usize) << shift;
                 return Ok(size);
             }
             shift += 7;
@@ -328,6 +328,6 @@ mod tests {
         assert!(super::deserialize(b"\0").is_err());
 
         // these failed fuzz testing for this deserializer (V2)
-
+        assert!(Macaroon::deserialize(&vec![2, 2, 212, 212, 212, 212]).is_err());
     }
 }

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -67,7 +67,7 @@ impl<'r> Deserializer<'r> {
     }
 
     fn get_byte(&mut self) -> Result<u8> {
-        if self.index > self.data.len() - 1 {
+        if self.data.is_empty() || self.index > self.data.len() - 1 {
             return Err(MacaroonError::DeserializationError(String::from(
                 "Buffer overrun",
             )));

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -319,4 +319,15 @@ mod tests {
         };
         assert_eq!("https://auth.mybank.com", location);
     }
+
+    #[test]
+    fn test_deserialize_bad_data() {
+        // these are all expected to fail... but not panic!
+        assert!(super::deserialize(b"").is_err());
+        assert!(super::deserialize(b"12345").is_err());
+        assert!(super::deserialize(b"\0").is_err());
+
+        // these failed fuzz testing for this deserializer (V2)
+
+    }
 }


### PR DESCRIPTION
I ran in to some trivial `panic`s on things like an empty bytestring.

I did some casual fuzz testing using `cargo-fuzz` (following the [tutorial](https://rust-fuzz.github.io/book/cargo-fuzz/tutorial.html)) using that new function, and found several other panics. I'm not including the fuzz test boilerplate code in this commit because it was a ton of small extra files, but I can add that in the future if it would be helpful.

Regression tests are included. They all use the verbatim byte arrays that the fuzz tester outputs.