### PR TITLE
Refactor `(de)serialization` methods; make base64 decode flexible to URL safety

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,10 +384,30 @@ impl Macaroon {
         }
     }
 
-    /// Deserialize an encoded macaroon token, inferring the [Format]
+    /// Deserialize an encoded macaroon token, inferring the [Format].
     ///
     /// For V1 and V2 tokens, this assumes base64 encoding, in either "standard" or URL-safe
     /// encoding, with or without padding.
+    ///
+    /// For V2JSON tokens, the token must begin with the `{` character with no preceeding whitespace.
+    ///
+    /// ## Usage
+    ///
+    /// ```rust
+    /// use macaroon::Macaroon;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    ///
+    /// // '&str' gets automatically de-referenced to bytes ('&[u8]').
+    /// // 'b"byte-string"' or slice of 'u8' would also work.
+    /// let mac = Macaroon::deserialize("MDAxY2xvY2F0aW9uIGh0dHA6Ly9teWJhbmsvCjAwMjZpZGVudGlmaWVyIHdlIHVzZWQgb3VyIHNlY3JldCBrZXkKMDAxNmNpZCB0ZXN0ID0gY2F2ZWF0CjAwMmZzaWduYXR1cmUgGXusegRK8zMyhluSZuJtSTvdZopmDkTYjOGpmMI9vWcK")?;
+    ///
+    /// let mac_v2json = Macaroon::deserialize(r#"{"v":2,"l":"http://example.org/","i":"keyid", "c":[{"i":"account = 3735928559"},{"i":"user = alice"}],"s64": "S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw"}"#)?;
+    ///
+    /// // expect this to fail; leading whitespace is not allowed
+    /// Macaroon::deserialize(r#"   {"v":2,"l":"http://example.org/","i":"keyid", "c":[{"i":"account = 3735928559"},{"i":"user = alice"}],"s64": "S-lnzR6gxrJrr2pKlO6bBbFYhtoLqF6MQqk8jQ4SXvw"}"#).unwrap_err();
+    /// # Ok(()) }
+    /// ```
     pub fn deserialize<T: AsRef<[u8]>>(token: T) -> Result<Macaroon> {
         if token.as_ref().is_empty() {
             return Err(MacaroonError::DeserializationError(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ impl Macaroon {
     ///
     /// # Errors
     ///
-    /// Returns `MacaroonError::IncompleteMacaroon` if the identifier is empty
+    /// Returns `MacaroonError::IncompleteMacaroon` if the identifier bytestring is empty
     pub fn create(
         location: Option<String>,
         key: &MacaroonKey,
@@ -280,12 +280,15 @@ impl Macaroon {
         self.identifier.clone()
     }
 
-    /// Returns the location for the macaroon
+    /// Returns a clone the location for the macaroon
     pub fn location(&self) -> Option<String> {
         self.location.clone()
     }
 
     /// Returns the macaroon's signature
+    ///
+    /// The [MacaroonKey] type is used because it is the same size and format a signature, but the
+    /// signature is not and should be used as a cryptographic key.
     pub fn signature(&self) -> MacaroonKey {
         self.signature
     }
@@ -312,7 +315,11 @@ impl Macaroon {
             .collect()
     }
 
-    /// Validate the macaroon - used mainly for validating deserialized macaroons
+    /// Validate that a Macaroon has all the expected fields
+    ///
+    /// This is a low-level function to confirm that a macaroon was constructured correctly. It
+    /// does *not* verify the signature, caveats, or in any way confirm that a macaroon is
+    /// authentic from a security standpoint.
     fn validate(self) -> Result<Self> {
         if self.identifier.0.is_empty() {
             return Err(MacaroonError::IncompleteMacaroon("no identifier found"));

--- a/src/serialization/v2json.rs
+++ b/src/serialization/v2json.rs
@@ -179,10 +179,10 @@ impl Macaroon {
     }
 }
 
-pub fn serialize(macaroon: &Macaroon) -> Result<Vec<u8>> {
+pub fn serialize(macaroon: &Macaroon) -> Result<String> {
     let serialized: String =
         serde_json::to_string(&Serialization::from_macaroon(macaroon.clone())?)?;
-    Ok(serialized.into_bytes())
+    Ok(serialized)
 }
 
 pub fn deserialize(data: &[u8]) -> Result<Macaroon> {


### PR DESCRIPTION
The main thing this PR does is change the function signature and behavior of the `serialize` and `deserialize` functions. The main commit message describes the changes and motivation. The same commit also makes a related change to base64 decoding of macaroons, to be flexible about whether they use the URL-safe character set or not.

I switched serialize to return `String` instead of `Vec<u8>` because it is always a UTF-8 encoded string (base64 or JSON), and it is better and more efficient to return the most "specific" type. A user can convert to bytes with the trivial `as_bytes()`, but a `from_utf8()` requires a full pass and could fail.

The `AsRef` generic on `deserialize` is enough of an ergonomics improvement that I think it is worth possible compile time overhead or size increase.

There is also a small patch of doc improvements on the `Macaroon` struct which are not directly related.